### PR TITLE
fix(utils.py): correct indentation after 'if' statement at line 191

### DIFF
--- a/kenya_compliance/kenya_compliance/utils.py
+++ b/kenya_compliance/kenya_compliance/utils.py
@@ -188,7 +188,7 @@ def get_environment_settings(
     # Append the branch_id condition to the query if provided
     if branch_id:
     # Append the branch_id condition to the query
-    query += f" AND bhfid = '{branch_id}';"
+     query += f" AND bhfid = '{branch_id}';"
     
     # Execute the query
     setting_doctype = frappe.db.sql(query, as_dict=True)


### PR DESCRIPTION
This PR fixes an IndentationError in utils.py at line 191.  
The error occurred after an 'if' statement without an indented block, which caused compilation to fail during update.  

- Fixed indentation at line 191  
- Confirmed the app compiles successfully after the change  