### PR TITLE
fix(ci): pin mariadb-client to 10.6 in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,12 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install MariaDB Client
-        run: sudo apt-get install mariadb-client-10.6
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common curl
+          curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version=10.6
+          sudo apt-get update
+          sudo apt-get install -y mariadb-client
 
       - name: Setup
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y software-properties-common curl
-          curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version=10.6
+          curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version=10.6.23
           sudo apt-get update
           sudo apt-get install -y mariadb-client
 


### PR DESCRIPTION
 ### Summary
This PR resolves the GitHub Actions CI failure where `mariadb-client-10.6` was not found.

### Changes
- Added MariaDB’s official repo for Ubuntu in CI workflow
- Ensured `mariadb-client-10.6` installs successfully
- Keeps version consistent with Frappe Cloud (MariaDB 10.6)